### PR TITLE
Update gocron to fix non running jobs with weeks or days units

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -230,11 +230,13 @@ func (j *Job) scheduleNextRun() error {
 
 	switch j.unit {
 	case days:
+		j.shouldDo = true
 		j.mu.Lock()
 		j.nextRun = j.roundToMidnight(j.lastRun)
 		j.nextRun = j.nextRun.Add(j.atTime)
 		j.mu.Unlock()
 	case weeks:
+		j.shouldDo = true
 		j.mu.Lock()
 		j.nextRun = j.roundToMidnight(j.lastRun)
 		dayDiff := int(j.startDay)


### PR DESCRIPTION
gocron.Every() does not run jobs with weeks or days unit
->gocron.Every(1).Monday()
->gocron.Every(1).Day
->gocron.Every(2).Days
Mainly because gocron.Every() uses a default scheduler and default scheduler sets job.shouldRun at false.
shouldRun is consequently set to true in the scheduleNextRun function but only for jobs with unit other than weeks or days, hence the fix.